### PR TITLE
located response info within display receipt

### DIFF
--- a/receiptifyv1/public/server.js
+++ b/receiptifyv1/public/server.js
@@ -707,6 +707,7 @@ const displayReceipt = (response, stats) => {
   } else {
     $('#save-playlist').hide();
   }
+  console.log(responseItems);
 };
 
 function getAvg(arr) {


### PR DESCRIPTION
Added a debug print after display receipt to show where we can save the receipt to a log file.